### PR TITLE
add CityRepository for managing city entries

### DIFF
--- a/ServidorCentral/src/main/java/com/servidorcentral/exceptions/CityAlreadyExistsException.java
+++ b/ServidorCentral/src/main/java/com/servidorcentral/exceptions/CityAlreadyExistsException.java
@@ -1,0 +1,13 @@
+package com.servidorcentral.exceptions;
+
+public class CityAlreadyExistsException extends Exception {
+
+    public CityAlreadyExistsException(String message) {
+        super(message);
+    }
+
+    public CityAlreadyExistsException() {
+        super("City already exists");
+    }
+
+}

--- a/ServidorCentral/src/main/java/com/servidorcentral/repositories/CityRepository.java
+++ b/ServidorCentral/src/main/java/com/servidorcentral/repositories/CityRepository.java
@@ -1,0 +1,42 @@
+package com.servidorcentral.repositories;
+
+import com.servidorcentral.enums.Country;
+import com.servidorcentral.exceptions.CityAlreadyExistsException;
+import com.servidorcentral.models.City;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+public class CityRepository {
+
+    private static CityRepository instance;
+    private final Set<City> cities;
+
+    public static CityRepository getInstance() {
+        if (instance == null) {
+            instance = new CityRepository();
+        }
+        return instance;
+    }
+
+    private CityRepository() {
+        this.cities = new HashSet<>();
+    }
+
+    public void addCity(City city) throws CityAlreadyExistsException {
+        if (this.cities.contains(city)) {
+            throw new CityAlreadyExistsException("City already exists: " + city.getName() + ", " + city.getCountry().getName());
+        }
+
+        this.cities.add(city);
+    }
+
+    public Optional<City> getCity(String name, Country country) {
+        return this.cities.stream()
+                .filter(each -> each.getName().equals(name) && each.getCountry() == country)
+                .findAny();
+    }
+
+}
+


### PR DESCRIPTION
Exception Handling:

* [`ServidorCentral/src/main/java/com/servidorcentral/exceptions/CityAlreadyExistsException.java`](diffhunk://#diff-8d9c990e7df24668d68467a7d23e8e44b8d2b70f35d7759f1bb4c0b79f88b9dbR1-R13): Introduced a new custom exception `CityAlreadyExistsException` to handle cases where a city already exists in the repository.

Repository Management:

* [`ServidorCentral/src/main/java/com/servidorcentral/repositories/CityRepository.java`](diffhunk://#diff-7320010cea465af5201abaa0f80d7f7bbc51b261e80c72818ffcb963c6478cafR1-R42): Added the `CityRepository` class with a singleton pattern, methods to add a city (which throws `CityAlreadyExistsException` if the city already exists), and a method to retrieve a city by name and country.